### PR TITLE
Fixed error missing GithubSslSupport

### DIFF
--- a/src/com/kodokux/github/api/GithubApiUtil.java
+++ b/src/com/kodokux/github/api/GithubApiUtil.java
@@ -141,40 +141,36 @@ public class GithubApiUtil {
                                    @NotNull final Collection<Header> headers,
                                    @NotNull final HttpVerb verb) throws IOException {
     HttpClient client = getHttpClient(auth.getBasicAuth(), auth.isUseProxy());
-    return GithubSslSupport.getInstance()
-      .executeSelfSignedCertificateAwareRequest(client, uri, new ThrowableConvertor<String, HttpMethod, IOException>() {
-        @Override
-        public HttpMethod convert(String uri) throws IOException {
-          HttpMethod method;
-          switch (verb) {
-            case POST:
-              method = new PostMethod(uri);
-              if (requestBody != null) {
-                ((PostMethod)method).setRequestEntity(new StringRequestEntity(requestBody, "application/json", "UTF-8"));
-              }
-              break;
-            case GET:
-              method = new GetMethod(uri);
-              break;
-            case DELETE:
-              method = new DeleteMethod(uri);
-              break;
-            case HEAD:
-              method = new HeadMethod(uri);
-              break;
-            default:
-              throw new IllegalStateException("Wrong HttpVerb: unknown method: " + verb.toString());
-          }
-          GithubAuthData.TokenAuth tokenAuth = auth.getTokenAuth();
-          if (tokenAuth != null) {
-            method.addRequestHeader("Authorization", "token " + tokenAuth.getToken());
-          }
-          for (Header header : headers) {
-            method.addRequestHeader(header);
-          }
-          return method;
+    HttpMethod method;
+    switch (verb) {
+      case POST:
+        method = new PostMethod(uri);
+        if (requestBody != null) {
+          ((PostMethod)method).setRequestEntity(new StringRequestEntity(requestBody, "application/json", "UTF-8"));
         }
-      });
+        break;
+      case GET:
+        method = new GetMethod(uri);
+        break;
+      case DELETE:
+        method = new DeleteMethod(uri);
+        break;
+      case HEAD:
+        method = new HeadMethod(uri);
+        break;
+      default:
+        throw new IllegalStateException("Wrong HttpVerb: unknown method: " + verb.toString());
+    }
+    GithubAuthData.TokenAuth tokenAuth = auth.getTokenAuth();
+    if (tokenAuth != null) {
+      method.addRequestHeader("Authorization", "token " + tokenAuth.getToken());
+    }
+    for (Header header : headers) {
+      method.addRequestHeader(header);
+    }
+
+    client.executeMethod(method);
+    return method;
   }
 
   @NotNull


### PR DESCRIPTION
The github plugin no longer contains the ssl support.
Jetbrains removed it them self and replaced it with the code I used.

for more information: http://git.jetbrains.org/?p=idea/community.git;a=blobdiff;f=plugins/github/src/org/jetbrains/plugins/github/api/GithubApiUtil.java;h=6a07e8798f64b12418933533f9c125854b4eacb3;hp=885f252d65e4df3efca2df71588dcf812a1194b3;hb=597982bcf19db31cfdff8c165e7e440e71950791;hpb=3287d5d260902cb673be607e7a85e986e5e063de
